### PR TITLE
Strings and literals as Uint8Arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ npm install emailjs-imap-handler
 
 To parse a command you need to have the command as one complete Uint8Array (including all literals) without the ending &lt;CR&gt;&lt;LF&gt;
 
-    imapHandler.parser(imapCommand);
+    imapHandler.parser(imapCommand, options);
 
 Where
 
   * **imapCommand** is an Uint8Array without the final line break
+  * **options** contains options that affect the returned value
+
+Where available options are
+
+  * **valueAsString** LITERAL and STRING values are returned as strings rather than Uint8Array objects. Defaults to true.
 
 The function returns an object in the following form:
 

--- a/src/emailjs-imap-parser.js
+++ b/src/emailjs-imap-parser.js
@@ -38,17 +38,13 @@
     var ASCII_LEFT_BRACKET = 91;
     var ASCII_RIGHT_BRACKET = 93;
 
-    function fromCharCode(uint8Array, skip) {
-        skip = skip || [];
+    function fromCharCode(uint8Array) {
         var max = 10240;
         var begin = 0;
         var strings = [];
 
         for (var i = 0; i < uint8Array.length; i++) {
-            if (skip.indexOf(i) >= 0) {
-                strings.push(String.fromCharCode.apply(null, uint8Array.subarray(begin, i)));
-                begin = i + 1;
-            } else if (i - begin >= max) {
+            if (i - begin >= max) {
                 strings.push(String.fromCharCode.apply(null, uint8Array.subarray(begin, i)));
                 begin = i;
             }
@@ -58,7 +54,7 @@
         return strings.join('');
     }
 
-    function fromCharCodeTrimmed(uint8Array, skip) {
+    function fromCharCodeTrimmed(uint8Array) {
         var begin = 0;
         var end = uint8Array.length;
 
@@ -74,7 +70,7 @@
             uint8Array = uint8Array.subarray(begin, end);
         }
 
-        return fromCharCode(uint8Array, skip);
+        return fromCharCode(uint8Array);
     }
 
     function isEmpty(uint8Array) {
@@ -194,12 +190,38 @@
     }
 
     Node.prototype.getValue = function() {
-        var value = fromCharCode(this.uint8Array.subarray(this.valueStart, this.valueEnd), this.valueSkip);
+        var value = fromCharCode(this.getValueArray());
         return this.valueToUpperCase ? value.toUpperCase() : value;
     };
 
     Node.prototype.getValueLength = function() {
         return this.valueEnd - this.valueStart - this.valueSkip.length;
+    };
+
+    Node.prototype.getValueArray = function() {
+        var valueArray = this.uint8Array.subarray(this.valueStart, this.valueEnd);
+
+        if (this.valueSkip.length === 0) {
+            return valueArray;
+        }
+
+        var filteredArray = new Uint8Array(valueArray.length - this.valueSkip.length);
+        var begin = 0;
+        var offset = 0;
+        var skip = this.valueSkip.slice();
+
+        skip.push(valueArray.length);
+
+        skip.forEach(function(end) {
+            if (end > begin) {
+                var subArray = valueArray.subarray(begin, end);
+                filteredArray.set(subArray, offset);
+                offset += subArray.length;
+            }
+            begin = end + 1;
+        });
+
+        return filteredArray;
     };
 
     Node.prototype.equals = function(value, caseSensitive) {
@@ -312,6 +334,10 @@
 
         this.state = 'NORMAL';
 
+        if (this.options.valueAsString === undefined) {
+            this.options.valueAsString = true;
+        }
+
         this.processString();
     }
 
@@ -336,6 +362,12 @@
             switch (node.type.toUpperCase()) {
                 case 'LITERAL':
                 case 'STRING':
+                    elm = {
+                        type: node.type.toUpperCase(),
+                        value: this.options.valueAsString ? node.getValue() : node.getValueArray()
+                    };
+                    branch.push(elm);
+                    break;
                 case 'SEQUENCE':
                     elm = {
                         type: node.type.toUpperCase(),

--- a/src/emailjs-imap-parser.js
+++ b/src/emailjs-imap-parser.js
@@ -39,17 +39,14 @@
     var ASCII_RIGHT_BRACKET = 93;
 
     function fromCharCode(uint8Array) {
-        var max = 10240;
-        var begin = 0;
+        var batchSize = 10240;
         var strings = [];
 
-        for (var i = 0; i < uint8Array.length; i++) {
-            if (i - begin >= max) {
-                strings.push(String.fromCharCode.apply(null, uint8Array.subarray(begin, i)));
-                begin = i;
-            }
+        for (var i = 0; i < uint8Array.length; i += batchSize) {
+            var begin = i;
+            var end = Math.min(i + batchSize, uint8Array.length);
+            strings.push(String.fromCharCode.apply(null, uint8Array.subarray(begin, end)));
         }
-        strings.push(String.fromCharCode.apply(null, uint8Array.subarray(begin, i)));
 
         return strings.join('');
     }

--- a/test/imap-parser-unit.js
+++ b/test/imap-parser-unit.js
@@ -400,6 +400,19 @@
                 ]);
             });
 
+            it('should return literal as Uint8Array', function() {
+                var options = { valueAsString: false };
+                var results = imapHandler.parser(toUint8ArrayList('TAG1 CMD {4}\r\nabcd'), options);
+                var literal = results.attributes[0];
+
+                expect(literal.type).to.equal('LITERAL');
+                expect(literal.value instanceof Uint8Array).to.equal(true);
+                expect(literal.value.length).to.equal(4);
+                expect(literal.value[0]).to.equal(97);
+                expect(literal.value[1]).to.equal(98);
+                expect(literal.value[2]).to.equal(99);
+                expect(literal.value[3]).to.equal(100);
+            });
         });
 
         describe('ATOM Section', function() {


### PR DESCRIPTION
This enables the user to skip the to-string conversion of LITERAL and STRING Node values and instead get a subarray directly from the underlying Uint8Array. Saves time and memory.